### PR TITLE
Only run when --check-litter is given

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ disallow_untyped_decorators = true
 no_implicit_optional = true
 no_implicit_reexport = true
 strict_equality = true
-strict_concatenate = true
+extra_checks = true
 
 [tool.ruff]
 src = ["src", "tests"]

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,3 +1,4 @@
 ruff
 black
 mypy
+pytest>=7.4.1  # Added pluggy typing

--- a/src/pytest_litter/plugin/plugin.py
+++ b/src/pytest_litter/plugin/plugin.py
@@ -24,7 +24,7 @@ PARSER_GROUP = "pytest-litter"
 RUN_CHECK_OPTION_DEST_NAME = "check_litter"
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser) -> None:
     """Add options to pytest (pytest hook function)."""
     group = parser.getgroup(PARSER_GROUP)
     group.addoption(

--- a/src/pytest_litter/plugin/plugin.py
+++ b/src/pytest_litter/plugin/plugin.py
@@ -58,7 +58,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.stash[COMPARATOR_KEY] = SnapshotComparator(config=litter_config)
 
 
-@pytest.hookimpl(hookwrapper=True)  # type: ignore[misc]
+@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item: pytest.Item):  # type: ignore[no-untyped-def]
     yield
     if item.config.getoption(RUN_CHECK_OPTION_DEST_NAME):

--- a/tests/system_test/system_test.sh
+++ b/tests/system_test/system_test.sh
@@ -13,7 +13,7 @@ python3 -m venv "${VENV}"
 "${VENV}/bin/python3" -m pip install --quiet --editable "${ROOT_DIR}" || exit 1
 
 echo "Executing system test..."
-pytest -p pytest-litter --basetemp=tmp  || exit 1
+pytest -p pytest-litter --basetemp=tmp --check-litter  || exit 1
 
 popd &> /dev/null || exit 1
 


### PR DESCRIPTION
Previously, litter checks always ran.
With this, litter checks only run when "--check-litter" is given to pytest.
