### PR TITLE
Support Python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: "ubuntu-latest"
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,12 @@ authors = [
 readme = "README.md"
 license = {file = "LICENSE"}
 urls = {repo = "https://github.com/mam-dev/pytest-litter"}
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 dependencies = ["pytest >= 6.1"]
 dynamic = ["version"]
 classifiers = [
   "Development Status :: 4 - Beta",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311,py312
+envlist = py38,py39,py310,py311,py312
 isolated_build = True
 minversion = 4.0.0
 


### PR DESCRIPTION
There are still a number of legacy applications that use python 3.8. It is meaningful to maintain support as 3.8 has not yet reached end-of-life: https://devguide.python.org/versions/